### PR TITLE
Allow reflective Java access for XStream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN git clone https://github.com/equinor/neqsimhome.git .
 
 RUN pip3 install -r requirements.txt
 
+# Allow reflective access for Java modules required by XStream under Java 21
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED"
+
 EXPOSE 8501
 
 HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health


### PR DESCRIPTION
## Summary
- open key java.base modules in Dockerfile so XStream can reflectively serialize classes under Java 21

## Testing
- `git ls-files '*.py' -z | xargs -0 python -m py_compile && echo 'py_compile done'`


------
https://chatgpt.com/codex/tasks/task_e_68bfd3fb8cf8832d8a99e71fa3b2b7dc